### PR TITLE
Fix js version to test with Travis CI

### DIFF
--- a/generators/script/templates/.travis.yml
+++ b/generators/script/templates/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
 node_js:
+  - "node"
+  - "6"
+  - "5"
+  - "4"
   - "0.12"
-  - "0.10"
   - "iojs"
 sudo: false
 cache:


### PR DESCRIPTION
Since version 0.10 does not have Promise, hubot-test-helper can not be used.

Travis CI log:

```console
...
$ npm test
...
  1) foobar responds to hello:
     ReferenceError: Promise is not defined
      at Room.receive (node_modules/hubot-test-helper/lib/index.js:79:18)
      at Object.Room.user.say (node_modules/hubot-test-helper/lib/index.js:62:26)
      at Context.<anonymous> (test/foobar-test.coffee:21:29)
  2) foobar hears orly:
     ReferenceError: Promise is not defined
      at Room.receive (node_modules/hubot-test-helper/lib/index.js:79:18)
      at Object.Room.user.say (node_modules/hubot-test-helper/lib/index.js:62:26)
      at Context.<anonymous> (test/foobar-test.coffee:27:29)
...
```

Remove version 0.10.
Add version the latest node and 6, 5, 4.