### PR TITLE
Remove references to hubot-scripts.json fixes #75

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -144,9 +144,6 @@ var HubotGenerator = yeoman.generators.Base.extend({
       'hubot-rules',
       'hubot-shipit'
     ];
-
-    this.hubotScripts = [
-    ];
   },
 
   prompting: {
@@ -250,7 +247,6 @@ var HubotGenerator = yeoman.generators.Base.extend({
       this.template('README.md', 'README.md');
 
       this.write('external-scripts.json', JSON.stringify(this.externalScripts, undefined, 2));
-      this.write('hubot-scripts.json', JSON.stringify(this.hubotScripts, undefined, 2));
 
       this.copy('gitignore', '.gitignore');
       this.template('_package.json', 'package.json');

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -24,7 +24,6 @@ describe('hubot:app', function () {
       'Procfile',
       'README.md',
       'external-scripts.json',
-      'hubot-scripts.json',
       '.gitignore',
       'package.json',
       'scripts/example.coffee',


### PR DESCRIPTION
This file is no longer used; the generator creates an empty one and the
bot then produces a warning to delete the empty file.  This patch just
removes the file from the generator so fresh installs never need to care
about this.

closes #75