### PR TITLE
Bumping the LTS versions for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 notifications:
   email: false
 node_js:
-  - "8" # stable
-  - "6" # LTS
-  - "4" # maintenance
+  - "10" # stable
+  - "8" # LTS
+  - "6" # maintenance
 before_script:
   - npm prune
 after_success:

--- a/generators/script/templates/.travis.yml
+++ b/generators/script/templates/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 notifications:
   email: false
 node_js:
-  - "8" # stable
-  - "6" # LTS
-  - "4" # maintenance
+  - "10" # stable
+  - "8" # LTS
+  - "6" # maintenance
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
April 30, 2018 has come and gone, which means new versions of `node` for test coverage.

Reference: https://github.com/nodejs/Release