### PR TITLE
feat(generators): use @latest tags

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -247,7 +247,7 @@ const HubotGenerator = yeoman.generators.Base.extend({
   },
 
   end: function () {
-    const packages = ['hubot'].concat(this.externalScripts).map(name => `${name}@next`)
+    const packages = ['hubot'].concat(this.externalScripts).map(name => `${name}@latest`)
 
     if (this.botAdapter !== 'campfire') {
       packages.push('hubot-' + this.botAdapter)


### PR DESCRIPTION
Now that Hubot 3 is stable, this sets the generator to create a Hubot using the v3 packages. We should create a release with the `latest` tag once this is ready.