### PR TITLE
chore: publish to default tag, not next

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "generator-hubot",
   "version": "0.0.0-development",
-  "publishConfig": {
-    "tag": "next"
-  },
   "description": "Hubot generator for Yeoman",
   "license": "MIT",
   "main": "generators/app/index.js",


### PR DESCRIPTION
I was wondering why things were being published under next 😅 This explains it.